### PR TITLE
break words to prevent big links from breaking the UI

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,4 +14,8 @@
  *= require_self
  */
 
- @import "bootstrap"
+@import "bootstrap";
+
+td {
+  word-break: break-all;
+}


### PR DESCRIPTION
fixed a syntax error, and added `word-break` to prevent long links from breaking the UI. Completely untested, have no clue how to run this locally ;)
